### PR TITLE
✨ [Feat] 카테고리 및 타이틀 로고 구현 - Crois

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ Dependencies/
 .DS_Store
 
 # End of https://www.toptal.com/developers/gitignore/api/xcode,swift,objective-c
+.DS_Store

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -41,8 +41,7 @@ class CategoryCollectionViewCell: UICollectionViewCell {
         categoryLabel.sizeToFit()
         
         categoryLabel.snp.makeConstraints {
-            $0.centerX.equalTo(contentView)
-            $0.centerY.equalTo(contentView)
+            $0.center.equalToSuperview()
             $0.width.equalTo(labelWidthSize + 40)
             $0.height.equalTo(labelHeightSize + 20)
         }

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -12,6 +12,7 @@ class CategoryCollectionViewCell: UICollectionViewCell {
     // 컬렉션뷰에 추가할 때 입력할 매개변수(identifier) 정의
     static let identifier: String = "CategoryCollectionViewCell"
     
+    // 카테고리 이름
     private let categoryList: [String] = ["All", "Burger", "Chicken", "Vegan", "Side", "Drink"]
     
     // 카테고리의 레이블 값 정의

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -13,9 +13,13 @@ class CategoryCollectionViewCell: UICollectionViewCell {
     
     private let categoryLabel: UILabel = {
         let label = UILabel()
+        label.text = "Vegan"
+        label.textAlignment = .center
         label.font = UIFont.systemFont(ofSize: 15, weight: .regular)
         label.textColor = UIColor.categoryText
         label.backgroundColor = UIColor.category
+        label.clipsToBounds = true
+        label.layer.cornerRadius = 20
         label.sizeToFit()
         label.translatesAutoresizingMaskIntoConstraints = false
         
@@ -33,8 +37,8 @@ class CategoryCollectionViewCell: UICollectionViewCell {
         categoryLabel.snp.makeConstraints {
             $0.centerX.equalTo(contentView)
             $0.centerY.equalTo(contentView)
-            $0.width.equalTo(labelWidthSize + 20)
-            $0.height.equalTo(labelHeightSize + 10)
+            $0.width.equalTo(labelWidthSize + 40)
+            $0.height.equalTo(labelHeightSize + 20)
         }
     }
     

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 import SnapKit
 
-class CategoryCollectionViewCell: UICollectionViewCell {
+final class CategoryCollectionViewCell: UICollectionViewCell {
     // 컬렉션뷰에 추가할 때 입력할 매개변수(identifier) 정의
     static let identifier: String = "CategoryCollectionViewCell"
     

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -15,6 +15,7 @@ class CategoryCollectionViewCell: UICollectionViewCell {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 15, weight: .regular)
         label.textColor = UIColor.categoryText
+        label.backgroundColor = UIColor.category
         label.sizeToFit()
         label.translatesAutoresizingMaskIntoConstraints = false
         
@@ -23,7 +24,7 @@ class CategoryCollectionViewCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        contentView.backgroundColor = UIColor.category
+        contentView.backgroundColor = UIColor.clear
         contentView.addSubview(categoryLabel)
         
         let labelWidthSize = categoryLabel.intrinsicContentSize.width

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -24,7 +24,6 @@ class CategoryCollectionViewCell: UICollectionViewCell {
         label.backgroundColor = UIColor.category
         label.clipsToBounds = true
         label.layer.cornerRadius = 20
-        label.sizeToFit()
         
         return label
     }()
@@ -39,6 +38,7 @@ class CategoryCollectionViewCell: UICollectionViewCell {
         
         let labelWidthSize = categoryLabel.intrinsicContentSize.width
         let labelHeightSize = categoryLabel.intrinsicContentSize.height
+        categoryLabel.sizeToFit()
         
         categoryLabel.snp.makeConstraints {
             $0.centerX.equalTo(contentView)
@@ -55,6 +55,18 @@ class CategoryCollectionViewCell: UICollectionViewCell {
     /// 인터페이스 빌더로 현재 뷰를 불러올 경우 fatalError를 발생시키지 않고 뷰 인스턴스를 생성
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        categoryLabel.text = "Vegan"
+        categoryLabel.textAlignment = .center
+        categoryLabel.font = UIFont.systemFont(ofSize: 15, weight: .regular)
+        categoryLabel.textColor = UIColor.categoryText
+        categoryLabel.backgroundColor = UIColor.category
+        categoryLabel.clipsToBounds = true
+        categoryLabel.layer.cornerRadius = 20
     }
     
     func editCategoryName(_ indexPath: Int) {

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -8,6 +8,6 @@
 import UIKit
 import SnapKit
 
-class CollectionView: UICollectionViewCell {
-    
+class CategoryCollectionViewCell: UICollectionViewCell {
+    let identifier: String = "CategoryCollectionViewCell"
 }

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -12,7 +12,7 @@ class CategoryCollectionViewCell: UICollectionViewCell {
     // 컬렉션뷰에 추가할 때 입력할 매개변수(identifier) 정의
     static let identifier: String = "CategoryCollectionViewCell"
     
-    private let menuList: [String] = ["All", "Burger", "Chicken", "Vegan", "Side", "Drink"]
+    private let categoryList: [String] = ["All", "Burger", "Chicken", "Vegan", "Side", "Drink"]
     
     // 카테고리의 레이블 값 정의
     private let categoryLabel: UILabel = {
@@ -48,7 +48,6 @@ class CategoryCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    
     /// 필수 생성 지정자
     /// - Parameter coder: 인터페이스 빌더 엔코딩 값
     ///
@@ -57,6 +56,7 @@ class CategoryCollectionViewCell: UICollectionViewCell {
         super.init(coder: coder)
     }
     
+    /// 컬렉션 뷰의 셀을 재사용하지 못하도록 리셋
     override func prepareForReuse() {
         super.prepareForReuse()
         
@@ -68,9 +68,14 @@ class CategoryCollectionViewCell: UICollectionViewCell {
         categoryLabel.clipsToBounds = true
         categoryLabel.layer.cornerRadius = 20
     }
-    
-    func editCategoryName(_ indexPath: Int) {
-        self.categoryLabel.text = menuList[indexPath]
+}
+
+// 카테고리 메소드
+extension CategoryCollectionViewCell {
+    /// 카테고리의 레이블 값을 세팅하는 메소드
+    /// - Parameter indexPath: 현재 셀의 index 값
+    func categoryLabelConfig(_ indexPath: Int) {
+        self.categoryLabel.text = categoryList[indexPath]
     }
     
     /// 선택된 카테고리를 강조하는 메소드

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -45,5 +45,10 @@ class CategoryCollectionViewCell: UICollectionViewCell {
         super.init(coder: coder)
     }
     
-//    func
+    func selectCategory(_ isSelected: Bool) {
+        guard isSelected else { return }
+        self.categoryLabel.backgroundColor = UIColor.personal
+        self.categoryLabel.textColor = .white
+        self.categoryLabel.font = UIFont.systemFont(ofSize: 18, weight: .bold)
+    }
 }

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 
 class CategoryCollectionViewCell: UICollectionViewCell {
-    let identifier: String = "CategoryCollectionViewCell"
+    static let identifier: String = "CategoryCollectionViewCell"
     
     private let categoryLabel: UILabel = {
         let label = UILabel()

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -9,8 +9,10 @@ import UIKit
 import SnapKit
 
 class CategoryCollectionViewCell: UICollectionViewCell {
+    // 컬렉션뷰에 추가할 때 입력할 매개변수(identifier) 정의
     static let identifier: String = "CategoryCollectionViewCell"
     
+    // 카테고리의 레이블 값 정의
     private let categoryLabel: UILabel = {
         let label = UILabel()
         label.text = "Vegan"
@@ -25,6 +27,9 @@ class CategoryCollectionViewCell: UICollectionViewCell {
         return label
     }()
     
+    
+    /// 컬렉션뷰 셀 아이템 기본 설정
+    /// - Parameter frame: 컬렉션뷰 셀 아이템의 frame 값 = .zero 설정
     override init(frame: CGRect) {
         super.init(frame: frame)
         contentView.backgroundColor = UIColor.clear
@@ -41,10 +46,17 @@ class CategoryCollectionViewCell: UICollectionViewCell {
         }
     }
     
+    
+    /// 필수 생성 지정자
+    /// - Parameter coder: 인터페이스 빌더 엔코딩 값
+    ///
+    /// 인터페이스 빌더로 현재 뷰를 불러올 경우 fatalError를 발생시키지 않고 뷰 인스턴스를 생성
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
     
+    /// 선택된 카테고리를 강조하는 메소드
+    /// - Parameter isSelected: 현재 카테고리가 선택되었는지 확인
     func selectCategory(_ isSelected: Bool) {
         guard isSelected else { return }
         self.categoryLabel.backgroundColor = UIColor.personal

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -21,7 +21,6 @@ class CategoryCollectionViewCell: UICollectionViewCell {
         label.clipsToBounds = true
         label.layer.cornerRadius = 20
         label.sizeToFit()
-        label.translatesAutoresizingMaskIntoConstraints = false
         
         return label
     }()
@@ -45,4 +44,6 @@ class CategoryCollectionViewCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
+    
+//    func
 }

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -10,4 +10,13 @@ import SnapKit
 
 class CategoryCollectionViewCell: UICollectionViewCell {
     let identifier: String = "CategoryCollectionViewCell"
+    
+    private let categoryLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 15, weight: .regular)
+        label.textColor = UIColor.categoryText
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
 }

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -12,6 +12,8 @@ class CategoryCollectionViewCell: UICollectionViewCell {
     // 컬렉션뷰에 추가할 때 입력할 매개변수(identifier) 정의
     static let identifier: String = "CategoryCollectionViewCell"
     
+    private let menuList: [String] = ["All", "Burger", "Chicken", "Vegan", "Side", "Drink"]
+    
     // 카테고리의 레이블 값 정의
     private let categoryLabel: UILabel = {
         let label = UILabel()
@@ -53,6 +55,10 @@ class CategoryCollectionViewCell: UICollectionViewCell {
     /// 인터페이스 빌더로 현재 뷰를 불러올 경우 fatalError를 발생시키지 않고 뷰 인스턴스를 생성
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+    }
+    
+    func editCategoryName(_ indexPath: Int) {
+        self.categoryLabel.text = menuList[indexPath]
     }
     
     /// 선택된 카테고리를 강조하는 메소드

--- a/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryCollectionViewCell.swift
@@ -15,8 +15,29 @@ class CategoryCollectionViewCell: UICollectionViewCell {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 15, weight: .regular)
         label.textColor = UIColor.categoryText
+        label.sizeToFit()
         label.translatesAutoresizingMaskIntoConstraints = false
         
         return label
     }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.backgroundColor = UIColor.category
+        contentView.addSubview(categoryLabel)
+        
+        let labelWidthSize = categoryLabel.intrinsicContentSize.width
+        let labelHeightSize = categoryLabel.intrinsicContentSize.height
+        
+        categoryLabel.snp.makeConstraints {
+            $0.centerX.equalTo(contentView)
+            $0.centerY.equalTo(contentView)
+            $0.width.equalTo(labelWidthSize + 20)
+            $0.height.equalTo(labelHeightSize + 10)
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
 }

--- a/iMacDonald/iMacDonald/CollectionView/CategoryView.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryView.swift
@@ -10,7 +10,7 @@ import SnapKit
 
 
 /// 커스텀 카테고리뷰
-class CategoryView: UIView {
+final class CategoryView: UIView {
     
     private var collectionView: UICollectionView
     private let titleLogo = UILabel()

--- a/iMacDonald/iMacDonald/CollectionView/CategoryView.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryView.swift
@@ -1,0 +1,135 @@
+//
+//  CategoryView.swift
+//  iMacDonald
+//
+//  Created by 장상경 on 11/26/24.
+//
+
+import UIKit
+import SnapKit
+
+class CategoryView: UIView {
+    
+    private var collectionView: UICollectionView
+    private let titleLogo = UILabel()
+    private var state: CollectionViewTestMenuCategory = .all
+    private var currentState: Int = 0
+    
+    override init(frame: CGRect) {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.itemSize = CGSize(width: 80, height: 50)
+        layout.minimumLineSpacing = 10
+        
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        super.init(frame: frame)
+
+        setupUIConfig()
+    }
+    
+    required init?(coder: NSCoder) {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.itemSize = CGSize(width: 80, height: 50)
+        layout.minimumLineSpacing = 10
+        
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        super.init(coder: coder)
+        
+        setupUIConfig()
+    }
+    
+    private func setupUIConfig() {
+        setupLogo()
+        setupCollectionView()
+    }
+}
+
+extension CategoryView {
+    private func setupLogo() {
+        titleLogo.text = "iMacDonald"
+        titleLogo.font = UIFont.systemFont(ofSize: 30, weight: .black)
+        titleLogo.backgroundColor = UIColor.clear
+        titleLogo.textAlignment = .center
+        titleLogo.textColor = UIColor.personal
+        self.addSubview(titleLogo)
+        
+        titleLogo.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalToSuperview()
+            $0.height.equalTo(50)
+        }
+    }
+    
+    private func setupCollectionView() {
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.register(CategoryCollectionViewCell.self, forCellWithReuseIdentifier: CategoryCollectionViewCell.identifier)
+        collectionView.backgroundColor = UIColor.clear
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.showsHorizontalScrollIndicator = false
+        
+        self.addSubview(collectionView)
+        
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(titleLogo.snp.bottom)
+            $0.leading.equalToSuperview().offset(20)
+            $0.trailing.equalToSuperview()
+            $0.height.equalTo(50)
+        }
+    }
+}
+
+extension CategoryView: UICollectionViewDelegate, UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return CollectionViewTestMenuCategory.allCases.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCollectionViewCell.identifier, for: indexPath) as! CategoryCollectionViewCell
+        
+        cell.categoryLabelConfig(indexPath.item)
+        
+        let isSelected: Bool = indexPath.item == currentState
+        cell.selectCategory(isSelected)
+        
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+        switch indexPath.item {
+        case 0:
+            self.state = .all
+        case 1:
+            self.state = .burger
+        case 2:
+            self.state = .chicken
+        case 3:
+            self.state = .vegan
+        case 4:
+            self.state = .side
+        case 5:
+            self.state = .drink
+        default:
+            break
+        }
+        
+        switch self.state {
+        case .all:
+            self.currentState = 0
+        case .burger:
+            self.currentState = 1
+        case .chicken:
+            self.currentState = 2
+        case .vegan:
+            self.currentState = 3
+        case .side:
+            self.currentState = 4
+        case .drink:
+            self.currentState = 5
+        }
+                
+        collectionView.reloadData()
+    }
+}

--- a/iMacDonald/iMacDonald/CollectionView/CategoryView.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryView.swift
@@ -55,9 +55,9 @@ final class CategoryView: UIView {
 }
 
 // 카테고리뷰 클래스의 뷰 요소 세팅 메소드
-extension CategoryView {
+private extension CategoryView {
     /// 로고의 세팅 메소드
-    private func setupLogo() {
+    func setupLogo() {
         titleLogo.text = "iMacDonald"
         titleLogo.font = UIFont.systemFont(ofSize: 30, weight: .black)
         titleLogo.backgroundColor = UIColor.clear
@@ -73,7 +73,7 @@ extension CategoryView {
     }
     
     /// 컬렉션뷰의 세팅 메소드
-    private func setupCollectionView() {
+    func setupCollectionView() {
         collectionView.delegate = self
         collectionView.dataSource = self
         collectionView.register(CategoryCollectionViewCell.self, forCellWithReuseIdentifier: CategoryCollectionViewCell.identifier)

--- a/iMacDonald/iMacDonald/CollectionView/CategoryView.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryView.swift
@@ -8,6 +8,8 @@
 import UIKit
 import SnapKit
 
+
+/// 커스텀 카테고리뷰
 class CategoryView: UIView {
     
     private var collectionView: UICollectionView
@@ -15,6 +17,8 @@ class CategoryView: UIView {
     private var state: CollectionViewTestMenuCategory = .all
     private var currentState: Int = 0
     
+    /// 카테고리뷰 생성 이니셜라이저
+    /// - Parameter frame: 카테고리뷰가 가지는 frame = .zero
     override init(frame: CGRect) {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
@@ -27,6 +31,10 @@ class CategoryView: UIView {
         setupUIConfig()
     }
     
+    /// 필수 생성자
+    /// - Parameter coder: 인터페이스빌더의 엔코딩 값
+    ///
+    /// 인터페이스빌더를 통해 뷰를 호출할 경우 인스턴스 생성
     required init?(coder: NSCoder) {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
@@ -39,13 +47,16 @@ class CategoryView: UIView {
         setupUIConfig()
     }
     
+    /// 컬렉션 뷰와 로고의 세팅 메소드
     private func setupUIConfig() {
         setupLogo()
         setupCollectionView()
     }
 }
 
+// 카테고리뷰 클래스의 뷰 요소 세팅 메소드
 extension CategoryView {
+    /// 로고의 세팅 메소드
     private func setupLogo() {
         titleLogo.text = "iMacDonald"
         titleLogo.font = UIFont.systemFont(ofSize: 30, weight: .black)
@@ -61,6 +72,7 @@ extension CategoryView {
         }
     }
     
+    /// 컬렉션뷰의 세팅 메소드
     private func setupCollectionView() {
         collectionView.delegate = self
         collectionView.dataSource = self
@@ -80,6 +92,7 @@ extension CategoryView {
     }
 }
 
+// 컬렉션뷰의 델리게이트 및 데이터소스 구현부
 extension CategoryView: UICollectionViewDelegate, UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return CollectionViewTestMenuCategory.allCases.count

--- a/iMacDonald/iMacDonald/CollectionView/CategoryView.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CategoryView.swift
@@ -18,8 +18,8 @@ class CategoryView: UIView {
     override init(frame: CGRect) {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
-        layout.itemSize = CGSize(width: 80, height: 50)
-        layout.minimumLineSpacing = 10
+        layout.itemSize = CGSize(width: 90, height: 50)
+        layout.minimumLineSpacing = 5
         
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         super.init(frame: frame)
@@ -30,7 +30,7 @@ class CategoryView: UIView {
     required init?(coder: NSCoder) {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
-        layout.itemSize = CGSize(width: 80, height: 50)
+        layout.itemSize = CGSize(width: 90, height: 50)
         layout.minimumLineSpacing = 10
         
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)

--- a/iMacDonald/iMacDonald/CollectionView/CollectionView.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionView.swift
@@ -6,7 +6,8 @@
 //
 
 import UIKit
+import SnapKit
 
-class CollectionView: UICollectionView {
+class CollectionView: UICollectionViewCell {
     
 }

--- a/iMacDonald/iMacDonald/CollectionView/CollectionView.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionView.swift
@@ -2,6 +2,6 @@
 //  CollectionView.swift
 //  iMacDonald
 //
-//  Created by 유태호 on 11/25/24.
+//  컬렉션 뷰 담당: 장상경
 //
 

--- a/iMacDonald/iMacDonald/CollectionView/CollectionView.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionView.swift
@@ -5,3 +5,8 @@
 //  컬렉션 뷰 담당: 장상경
 //
 
+import UIKit
+
+class CollectionView: UICollectionView {
+    
+}

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewPreview.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewPreview.swift
@@ -1,0 +1,8 @@
+//
+//  CollectionViewPreview.swift
+//  iMacDonald
+//
+//  Created by 장상경 on 11/26/24.
+//
+
+import Foundation

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewPreview.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewPreview.swift
@@ -5,4 +5,33 @@
 //  Created by 장상경 on 11/26/24.
 //
 
-import Foundation
+import UIKit
+import SwiftUI
+
+// SwiftUI Preview를 통해 UIKit ViewController 미리보기
+struct MyViewControllerPreview: PreviewProvider {
+    static var previews: some View {
+        ViewControllerPreview {
+            CollectionViewTestController()
+        }
+        .edgesIgnoringSafeArea(.all) // 전체 화면 미리보기로 설정
+    }
+}
+
+// SwiftUI의 UIViewControllerRepresentable을 사용해 UIKit 뷰를 SwiftUI에서 사용
+struct ViewControllerPreview<ViewController: UIViewController>: UIViewControllerRepresentable {
+    
+    let viewController: ViewController
+    
+    init(_ builder: @escaping () -> ViewController) {
+        self.viewController = builder()
+    }
+    
+    func makeUIViewController(context: Context) -> ViewController {
+        return viewController
+    }
+    
+    func updateUIViewController(_ uiViewController: ViewController, context: Context) {
+        // UI 업데이트 필요 시 여기에 작성
+    }
+}

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import SnapKit
 
+// 테스트용 ViewController
 class CollectionViewTestController: UIViewController {
 
     private let category = CategoryView()

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -15,7 +15,7 @@ class CollectionViewTestController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
         
         setupCategory()
     }

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -101,9 +101,9 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
         case 3:
             self.state = .vegan
         case 4:
-            self.state = .drink
-        case 5:
             self.state = .side
+        case 5:
+            self.state = .drink
         default:
             break
         }
@@ -121,8 +121,6 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
             self.currentCategory = 4
         case .drink:
             self.currentCategory = 5
-        default:
-            break
         }
         
         label.text = self.state.rawValue

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -53,8 +53,8 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
     private func setupCollectionView() {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
-        layout.itemSize = CGSize(width: 100, height: 50)
-        layout.minimumLineSpacing = 5
+        layout.itemSize = CGSize(width: 80, height: 50)
+        layout.minimumLineSpacing = 10
         
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView?.delegate = self
@@ -76,6 +76,19 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return 6
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCollectionViewCell.identifier, for: indexPath) as! CategoryCollectionViewCell
+        
+        cell.editCategoryName(indexPath.item)
+        
+        let isSelected: Bool = indexPath.item == currentCategory
+        cell.selectCategory(isSelected)
+        
+//        collectionView.reloadData()
+        
+        return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -117,16 +130,5 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
         label.text = self.state.rawValue
         
         collectionView.reloadData()
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCollectionViewCell.identifier, for: indexPath) as! CategoryCollectionViewCell
-        
-        cell.editCategoryName(indexPath.item)
-        
-        let isSelected: Bool = indexPath.item == currentCategory
-        cell.selectCategory(isSelected)
-        
-        return cell
     }
 }

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -11,9 +11,9 @@ enum CollectionViewTestMenuCategory: String {
     case all
     case burger
     case chicken
+    case vegan
     case side
     case drink
-    case vegan
 }
 
 class CollectionViewTestController: UIViewController, UICollectionViewDataSource, UICollectionViewDelegate {
@@ -85,9 +85,7 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
         
         let isSelected: Bool = indexPath.item == currentCategory
         cell.selectCategory(isSelected)
-        
-//        collectionView.reloadData()
-        
+                
         return cell
     }
     
@@ -117,11 +115,11 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
             self.currentCategory = 1
         case .chicken:
             self.currentCategory = 2
-        case .side:
-            self.currentCategory = 3
-        case .drink:
-            self.currentCategory = 4
         case .vegan:
+            self.currentCategory = 3
+        case .side:
+            self.currentCategory = 4
+        case .drink:
             self.currentCategory = 5
         default:
             break

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -34,6 +34,8 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        view.backgroundColor = .white
+        
         setupLabel()
         setupCollectionView()
     }
@@ -59,6 +61,8 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
         collectionView?.dataSource = self
         collectionView?.register(CategoryCollectionViewCell.self, forCellWithReuseIdentifier: CategoryCollectionViewCell.identifier)
         collectionView?.backgroundColor = UIColor.clear
+        collectionView?.showsVerticalScrollIndicator = false
+        collectionView?.showsHorizontalScrollIndicator = false
         
         view.addSubview(collectionView!)
         
@@ -71,16 +75,7 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 3
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCollectionViewCell.identifier, for: indexPath) as! CategoryCollectionViewCell
-        
-        let isSelected: Bool = indexPath.item == currentCategory
-        cell.selectCategory(isSelected)
-        
-        return cell
+        return 6
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -115,8 +110,21 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
             self.currentCategory = 4
         case .vegan:
             self.currentCategory = 5
+        default:
+            break
         }
         
+        label.text = self.state.rawValue
+        
         collectionView.reloadData()
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCollectionViewCell.identifier, for: indexPath) as! CategoryCollectionViewCell
+        
+        let isSelected: Bool = indexPath.item == currentCategory
+        cell.selectCategory(isSelected)
+        
+        return cell
     }
 }

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -19,6 +19,7 @@ enum CollectionViewTestMenuCategory: String {
 class CollectionViewTestController: UIViewController, UICollectionViewDataSource, UICollectionViewDelegate {
     
     private var collectionView: UICollectionView?
+    private var currentCategory: Int = 0
     
     private var state: CollectionViewTestMenuCategory = .all
     private let label: UILabel = {
@@ -76,6 +77,46 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCollectionViewCell.identifier, for: indexPath) as! CategoryCollectionViewCell
         
+        let isSelected: Bool = indexPath.item == currentCategory
+        cell.selectCategory(isSelected)
+        
         return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+        switch indexPath.item {
+        case 0:
+            self.state = .all
+        case 1:
+            self.state = .burger
+        case 2:
+            self.state = .chicken
+        case 3:
+            self.state = .vegan
+        case 4:
+            self.state = .drink
+        case 5:
+            self.state = .side
+        default:
+            break
+        }
+        
+        switch self.state {
+        case .all:
+            self.currentCategory = 0
+        case .burger:
+            self.currentCategory = 1
+        case .chicken:
+            self.currentCategory = 2
+        case .side:
+            self.currentCategory = 3
+        case .drink:
+            self.currentCategory = 4
+        case .vegan:
+            self.currentCategory = 5
+        }
+        
+        collectionView.reloadData()
     }
 }

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -7,15 +7,6 @@
 
 import UIKit
 
-enum CollectionViewTestMenuCategory: String {
-    case all
-    case burger
-    case chicken
-    case vegan
-    case side
-    case drink
-}
-
 class CollectionViewTestController: UIViewController, UICollectionViewDataSource, UICollectionViewDelegate {
     
     private var collectionView: UICollectionView?

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -7,7 +7,8 @@
 
 import UIKit
 
-enum CollectionViewTestMenuCategory {
+enum CollectionViewTestMenuCategory: String {
+    case all
     case burger
     case chicken
     case side
@@ -19,10 +20,31 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
     
     private var collectionView: UICollectionView?
     
+    private var state: CollectionViewTestMenuCategory = .all
+    private let label: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 40, weight: .black)
+        label.textColor = UIColor.black
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setupLabel()
         setupCollectionView()
+    }
+    
+    private func setupLabel() {
+        label.text = self.state.rawValue
+        view.addSubview(label)
+        
+        label.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
     }
     
     private func setupCollectionView() {

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -6,15 +6,28 @@
 //
 
 import UIKit
+import SnapKit
 
 class CollectionViewTestController: UIViewController {
 
+    private let category = CategoryView()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         view.backgroundColor = .white
         
-
+        setupCategory()
+    }
+    
+    private func setupCategory() {
+        view.addSubview(category)
+        
+        category.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.equalToSuperview()
+            $0.trailing.equalToSuperview()
+            $0.height.equalTo(100)
+        }
     }
 }

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -7,9 +7,44 @@
 
 import UIKit
 
-class CollectionViewTestController: UIViewController {
+class CollectionViewTestController: UIViewController, UICollectionViewDataSource, UICollectionViewDelegate {
+    
+    private var collectionView: UICollectionView?
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        setupCollectionView()
+    }
+    
+    private func setupCollectionView() {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.itemSize = CGSize(width: 100, height: 50)
+        layout.minimumLineSpacing = 10
+        
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView?.delegate = self
+        collectionView?.dataSource = self
+        collectionView?.register(CategoryCollectionViewCell.self, forCellWithReuseIdentifier: CategoryCollectionViewCell.identifier)
+        collectionView?.backgroundColor = UIColor.clear
+        collectionView?.translatesAutoresizingMaskIntoConstraints = false
+        
+        view.addSubview(collectionView!)
+        
+        collectionView?.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.equalToSuperview()
+            $0.trailing.equalToSuperview()
+            $0.height.equalTo(50)
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        <#code#>
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        <#code#>
     }
 }

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 
 // 테스트용 ViewController
-class CollectionViewTestController: UIViewController {
+final class CollectionViewTestController: UIViewController {
 
     private let category = CategoryView()
     

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -41,10 +41,12 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        
+        return 3
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCollectionViewCell.identifier, for: indexPath) as! CategoryCollectionViewCell
         
+        return cell
     }
 }

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -54,7 +54,7 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         layout.itemSize = CGSize(width: 100, height: 50)
-        layout.minimumLineSpacing = 10
+        layout.minimumLineSpacing = 5
         
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView?.delegate = self

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -122,6 +122,8 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCollectionViewCell.identifier, for: indexPath) as! CategoryCollectionViewCell
         
+        cell.editCategoryName(indexPath.item)
+        
         let isSelected: Bool = indexPath.item == currentCategory
         cell.selectCategory(isSelected)
         

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -41,10 +41,10 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        <#code#>
+        
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        <#code#>
+        
     }
 }

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -7,6 +7,14 @@
 
 import UIKit
 
+enum CollectionViewTestMenuCategory {
+    case burger
+    case chicken
+    case side
+    case drink
+    case vegan
+}
+
 class CollectionViewTestController: UIViewController, UICollectionViewDataSource, UICollectionViewDelegate {
     
     private var collectionView: UICollectionView?

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -58,13 +58,12 @@ class CollectionViewTestController: UIViewController, UICollectionViewDataSource
         collectionView?.dataSource = self
         collectionView?.register(CategoryCollectionViewCell.self, forCellWithReuseIdentifier: CategoryCollectionViewCell.identifier)
         collectionView?.backgroundColor = UIColor.clear
-        collectionView?.translatesAutoresizingMaskIntoConstraints = false
         
         view.addSubview(collectionView!)
         
         collectionView?.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.leading.equalToSuperview()
+            $0.leading.equalToSuperview().offset(20)
             $0.trailing.equalToSuperview()
             $0.height.equalTo(50)
         }

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -7,115 +7,14 @@
 
 import UIKit
 
-class CollectionViewTestController: UIViewController, UICollectionViewDataSource, UICollectionViewDelegate {
-    
-    private var collectionView: UICollectionView?
-    private var currentCategory: Int = 0
-    
-    private var state: CollectionViewTestMenuCategory = .all
-    private let label: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 40, weight: .black)
-        label.textColor = UIColor.black
-        label.textAlignment = .center
-        
-        return label
-    }()
+class CollectionViewTestController: UIViewController {
+
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         view.backgroundColor = .white
         
-        setupLabel()
-        setupCollectionView()
-    }
-    
-    private func setupLabel() {
-        label.text = self.state.rawValue
-        view.addSubview(label)
-        
-        label.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.centerY.equalToSuperview()
-        }
-    }
-    
-    private func setupCollectionView() {
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .horizontal
-        layout.itemSize = CGSize(width: 80, height: 50)
-        layout.minimumLineSpacing = 10
-        
-        collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView?.delegate = self
-        collectionView?.dataSource = self
-        collectionView?.register(CategoryCollectionViewCell.self, forCellWithReuseIdentifier: CategoryCollectionViewCell.identifier)
-        collectionView?.backgroundColor = UIColor.clear
-        collectionView?.showsVerticalScrollIndicator = false
-        collectionView?.showsHorizontalScrollIndicator = false
-        
-        view.addSubview(collectionView!)
-        
-        collectionView?.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.leading.equalToSuperview().offset(20)
-            $0.trailing.equalToSuperview()
-            $0.height.equalTo(50)
-        }
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 6
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCollectionViewCell.identifier, for: indexPath) as! CategoryCollectionViewCell
-        
-        cell.editCategoryName(indexPath.item)
-        
-        let isSelected: Bool = indexPath.item == currentCategory
-        cell.selectCategory(isSelected)
-                
-        return cell
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        
-        switch indexPath.item {
-        case 0:
-            self.state = .all
-        case 1:
-            self.state = .burger
-        case 2:
-            self.state = .chicken
-        case 3:
-            self.state = .vegan
-        case 4:
-            self.state = .side
-        case 5:
-            self.state = .drink
-        default:
-            break
-        }
-        
-        switch self.state {
-        case .all:
-            self.currentCategory = 0
-        case .burger:
-            self.currentCategory = 1
-        case .chicken:
-            self.currentCategory = 2
-        case .vegan:
-            self.currentCategory = 3
-        case .side:
-            self.currentCategory = 4
-        case .drink:
-            self.currentCategory = 5
-        }
-        
-        label.text = self.state.rawValue
-        
-        collectionView.reloadData()
+
     }
 }

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestController.swift
@@ -1,0 +1,15 @@
+//
+//  CollectionViewTestController.swift
+//  iMacDonald
+//
+//  Created by 장상경 on 11/26/24.
+//
+
+import UIKit
+
+class CollectionViewTestController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestModel.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestModel.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-enum CollectionViewTestMenuCategory: String {
+enum CollectionViewTestMenuCategory: String, CaseIterable {
     case all
     case burger
     case chicken

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestModel.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestModel.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+// 테스트용 더미 데이터들
 enum CollectionViewTestMenuCategory: String, CaseIterable {
     case all
     case burger

--- a/iMacDonald/iMacDonald/CollectionView/CollectionViewTestModel.swift
+++ b/iMacDonald/iMacDonald/CollectionView/CollectionViewTestModel.swift
@@ -1,0 +1,39 @@
+//
+//  CollectionViewTestModel.swift
+//  iMacDonald
+//
+//  Created by 장상경 on 11/26/24.
+//
+
+import UIKit
+
+enum CollectionViewTestMenuCategory: String {
+    case all
+    case burger
+    case chicken
+    case vegan
+    case side
+    case drink
+}
+
+struct CollectionViewTestModel {
+    var name: String
+    var price: Int
+    var image: UIImage?
+    var category: CollectionViewTestMenuCategory
+    
+    static let menuList: [CollectionViewTestModel] = [
+        CollectionViewTestModel(name: "test1", price: 1, category: .burger),
+        CollectionViewTestModel(name: "test2", price: 2, category: .burger),
+        CollectionViewTestModel(name: "test3", price: 3, category: .burger),
+        CollectionViewTestModel(name: "test4", price: 4, category: .chicken),
+        CollectionViewTestModel(name: "test5", price: 5, category: .chicken),
+        CollectionViewTestModel(name: "test6", price: 6, category: .chicken),
+        CollectionViewTestModel(name: "test7", price: 7, category: .vegan),
+        CollectionViewTestModel(name: "test8", price: 8, category: .vegan),
+        CollectionViewTestModel(name: "test9", price: 9, category: .side),
+        CollectionViewTestModel(name: "test10", price: 10, category: .side),
+        CollectionViewTestModel(name: "test11", price: 11, category: .side),
+        CollectionViewTestModel(name: "test12", price: 12, category: .drink)
+    ]
+}

--- a/iMacDonald/iMacDonald/SceneDelegate.swift
+++ b/iMacDonald/iMacDonald/SceneDelegate.swift
@@ -22,7 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let window = UIWindow(windowScene: windowScene)
         
         // window 에게 루트 뷰 지정.
-        window.rootViewController = CollectionViewTestController()
+        window.rootViewController = ViewController()
         
         // 이 메서드를 반드시 작성해줘야 윈도우가 활성화 됨.
         window.makeKeyAndVisible()

--- a/iMacDonald/iMacDonald/SceneDelegate.swift
+++ b/iMacDonald/iMacDonald/SceneDelegate.swift
@@ -22,7 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let window = UIWindow(windowScene: windowScene)
         
         // window 에게 루트 뷰 지정.
-        window.rootViewController = ViewController()
+        window.rootViewController = CollectionViewTestController()
         
         // 이 메서드를 반드시 작성해줘야 윈도우가 활성화 됨.
         window.makeKeyAndVisible()


### PR DESCRIPTION
# Create View: CategoryView

## ✨New Content✨
1.  커스텀된 `CollectionViewCell` 추가
2. 타이틀로고와 컬렉션뷰가 합쳐진 커스텀 `UIView` 모델 생성
3. 카테고리 선택시 강조 효과
4. 다크모드, 라이트모드에 따라 뷰 색상 변경

| Light Mode | Dark Mode |
| :-: | :-: |
| ![Simulator Screenshot - iPhone 16 Pro - 2024-11-26 at 18 59 36](https://github.com/user-attachments/assets/ba131bf9-a3f2-4454-b7b8-1d451151a3bd) | ![Simulator Screenshot - iPhone 16 Pro - 2024-11-26 at 19 03 23](https://github.com/user-attachments/assets/3bfc5f27-926c-461c-83ae-dd249cf6e0c8) |

## ♻️Changed Content♻️
-

## 🚨Trouble🚨

### 1. 카테고리 선택시 강조 효과가 선택하지 않은 셀에도 적용됨
 - `UICollectionView`는 셀을 재활용 하는데, 이 때문에 발생한 오류. 셀을 재사용하지 못하도록 리셋하는 방법으로 해결

### 2. 커스텀 UIView를 만드는 과정에서 반복적인 크래시 발생
 - `UICollectionView`의 경우 `layout`이라는 속성이 필요한데, UIView 를 초기화하는 단계에서 이를 찾을 수 없어 에러가 발생
 - `init`을 통한 초기화 단계에서 컬렉션뷰의 레이아웃을 설정하여 해결